### PR TITLE
feat(fe-mv): 장바구니 기능에 메뉴 옵션 편집 및 선택 추가하기

### DIFF
--- a/apps/frontend-menu-viewer/src/assets/icons/ic_cancel.svg
+++ b/apps/frontend-menu-viewer/src/assets/icons/ic_cancel.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.63672 5.63672L18.3646 18.3646" stroke="#404251" stroke-linecap="round"/>
+<path d="M18.3672 5.63672L5.63927 18.3646" stroke="#404251" stroke-linecap="round"/>
+</svg>

--- a/apps/frontend-menu-viewer/src/assets/icons/ic_check_thin.svg
+++ b/apps/frontend-menu-viewer/src/assets/icons/ic_check_thin.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 12L10.4615 15L16 9" stroke="#FFCD2A" stroke-linecap="round"/>
+</svg>

--- a/apps/frontend-menu-viewer/src/components/common/CheckBox.tsx
+++ b/apps/frontend-menu-viewer/src/components/common/CheckBox.tsx
@@ -10,7 +10,7 @@ export default function CheckBox({ checked, onClick }: Props) {
     <div
       onClick={onClick}
       className={`flex h-6 w-6 items-center justify-center rounded border transition-colors duration-200 ${
-        checked ? 'bg-main-500 border-main-500' : 'border-gray-200'
+        checked ? 'bg-main-500 border-main-500' : 'border-gray-200 bg-white'
       }`}
     >
       {checked && <CheckBoxCheckSvg width={20} height={20} />}

--- a/apps/frontend-menu-viewer/src/components/common/Header.tsx
+++ b/apps/frontend-menu-viewer/src/components/common/Header.tsx
@@ -5,13 +5,16 @@ import { useNavigate } from 'react-router';
 interface HeaderProps {
   title: string;
   backPath?: string;
+  onBackClick?: () => void;
 }
 
-export default function Header({ title, backPath }: HeaderProps) {
+export default function Header({ title, backPath, onBackClick }: HeaderProps) {
   const navigate = useNavigate();
   const canGoBack = window.history.length > 1;
 
   const handleBack = () => {
+    onBackClick?.();
+
     if (backPath) {
       navigate(backPath, { replace: true });
     } else if (canGoBack) {

--- a/apps/frontend-menu-viewer/src/components/common/MinMaxText.tsx
+++ b/apps/frontend-menu-viewer/src/components/common/MinMaxText.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  minSelectable?: number;
+  maxSelectable?: number;
+}
+
+export default function MinMaxText({ minSelectable, maxSelectable }: Props) {
+  return (
+    <p className="text-mc-2 flex items-center gap-1 text-gray-500">
+      {minSelectable && !(minSelectable === 1 && maxSelectable === 1) && (
+        <>
+          <span> 최소 {minSelectable}개</span>
+          <div className="h-1 w-1 rounded-full bg-gray-500"></div>
+        </>
+      )}
+      <span> 최대 {maxSelectable}개 선택</span>
+    </p>
+  );
+}

--- a/apps/frontend-menu-viewer/src/components/pages/Cart/OptionDropDown.tsx
+++ b/apps/frontend-menu-viewer/src/components/pages/Cart/OptionDropDown.tsx
@@ -42,7 +42,10 @@ export default function OptionDropDown({
         <ul className="space-y-1 mt-5">
           {group.items.map((item) =>
             selectedOptionIds.has(item.id) ? (
-              <li className="text-mc-1 text-gray-800 flex items-center">
+              <li
+                key={item.id}
+                className="text-mc-1 text-gray-800 flex items-center"
+              >
                 <CheckSvg />
                 <span>{item.name}</span>
               </li>

--- a/apps/frontend-menu-viewer/src/components/pages/Cart/OptionDropDown.tsx
+++ b/apps/frontend-menu-viewer/src/components/pages/Cart/OptionDropDown.tsx
@@ -1,0 +1,83 @@
+import { showCustomToast } from '../../../utilities/showToast';
+import MinMaxText from '../../common/MinMaxText';
+import OptionSelector from '../MenuDetail/OptionSelector';
+import CheckSvg from '@/assets/icons/ic_check_thin.svg?react';
+import ChervonDownSvg from '@/assets/icons/ic_chervon_down.svg?react';
+import ChervonUpSvg from '@/assets/icons/ic_chervon_up.svg?react';
+import { useState } from 'react';
+
+interface Props {
+  group: IOptionGroup;
+  selectedOptionIds: Set<string>;
+  onToggle: (itemId: string) => void;
+}
+
+export default function OptionDropDown({
+  group,
+  selectedOptionIds,
+  onToggle,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const type: 'radio' | 'checkbox' =
+    group.required && group.maxSelectable === 1 ? 'radio' : 'checkbox';
+  const isMaxReached = selectedOptionIds.size == group.maxSelectable;
+  return (
+    <li className="bg-gray-100 rounded-2xl p-5">
+      <div className="flex gap-5 items-start">
+        <div className="flex-1 space-y-1">
+          <h3 className="text-mb-3 text-gray-800">
+            <span>{group.title}</span>
+            {group.required && <span>필수</span>}
+          </h3>
+          <MinMaxText
+            minSelectable={group.minSelectable}
+            maxSelectable={group.maxSelectable}
+          />
+        </div>
+        <button onClick={() => setOpen((prev) => !prev)}>
+          {open ? <ChervonUpSvg /> : <ChervonDownSvg />}
+        </button>
+      </div>
+      {selectedOptionIds.size > 0 && (
+        <ul className="space-y-1 mt-5">
+          {group.items.map((item) =>
+            selectedOptionIds.has(item.id) ? (
+              <li className="text-mc-1 text-gray-800 flex items-center">
+                <CheckSvg />
+                <span>{item.name}</span>
+              </li>
+            ) : null,
+          )}
+        </ul>
+      )}
+      {open && (
+        <ul className="space-y-6 mt-5">
+          {group.items.map((item) => (
+            <OptionSelector
+              key={item.id}
+              type={type}
+              label={item.name}
+              price={item.price}
+              checked={selectedOptionIds.has(item.id)}
+              onChange={() => {
+                if (
+                  type === 'checkbox' &&
+                  isMaxReached &&
+                  !selectedOptionIds.has(item.id)
+                ) {
+                  showCustomToast({
+                    icon: 'error',
+                    message: `최대 ${group.maxSelectable}개까지만 선택할 수 있어요`,
+                  });
+                } else {
+                  onToggle(item.id);
+                }
+              }}
+              name={group.id}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/apps/frontend-menu-viewer/src/components/pages/Cart/OptionSelectorSheet.tsx
+++ b/apps/frontend-menu-viewer/src/components/pages/Cart/OptionSelectorSheet.tsx
@@ -1,13 +1,77 @@
-export default function OptionSelectorSheet() {
+import { isAllRequiredSelected } from '../../../utilities/isAllRequiredSelected';
+import BaseButton from '../../common/BaseButton';
+import ButtonWrapper from '../../common/ButtonWrapper';
+import OptionDropDown from './OptionDropDown';
+import CancelSvg from '@/assets/icons/ic_cancel.svg?react';
+
+interface Props {
+  menu: IMenuDetail;
+  selectedOptions: OptionSelection;
+  optionPrice: number;
+  menuId: string | null;
+  onToggle: (groupId: string, itemId: string, isSingle: boolean) => void;
+  onUpdate: (id: string, updates: Partial<ICartItem>) => void;
+  onClose: () => void;
+}
+
+export default function OptionSelectorSheet({
+  menu,
+  selectedOptions,
+  optionPrice,
+  menuId,
+  onToggle,
+  onUpdate,
+  onClose,
+}: Props) {
   return (
-    <div className="z-40 fixed inset-0 bg-black/25 min-w-xs xl:mx-auto xl:max-w-5xl w-full h-full">
-      <div className=" absolute bg-white bottom-0 h-5/6 w-full wrapper rounded-t-2xl p-5">
-        <div className="mb-6 flex items-center justify-between gap-12 pb-2">
-          <h2 className="text-mb-3 text-gray-900">{}</h2>
-          <button>엑스</button>
+    <div
+      onClick={onClose}
+      className=" z-40 fixed inset-0 bg-black/25 min-w-xs xl:mx-auto xl:max-w-5xl w-full h-full"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="animate-sheet-in scrollbar-hide overflow-y-auto absolute bg-white bottom-0 h-5/6 w-full rounded-t-2xl "
+      >
+        <div className="pt-5 wrapper bg-white sticky top-0 mb-6 flex items-center justify-between gap-12 pb-2">
+          <h2 className="text-mb-3 text-gray-900">{menu.name}</h2>
+          <button onClick={onClose}>
+            <CancelSvg />
+          </button>
         </div>
-        <ul></ul>
+        <ul className="space-y-3 wrapper">
+          {menu.optionGroups.map((group) => (
+            <OptionDropDown
+              key={group.id}
+              group={group}
+              selectedOptionIds={selectedOptions[group.id] ?? new Set()}
+              onToggle={(itemId) =>
+                onToggle(
+                  group.id,
+                  itemId,
+                  group.maxSelectable === 1 && group.required,
+                )
+              }
+            />
+          ))}
+        </ul>
+        <div className="h-48"></div>
       </div>
+      <ButtonWrapper>
+        <BaseButton
+          disabled={!isAllRequiredSelected(menu.optionGroups, selectedOptions)}
+          onClick={() => {
+            if (menuId) {
+              onUpdate(menuId, {
+                optionPrice: optionPrice,
+                selectedOptions: selectedOptions,
+              });
+              onClose();
+            }
+          }}
+        >
+          변경하기
+        </BaseButton>
+      </ButtonWrapper>
     </div>
   );
 }

--- a/apps/frontend-menu-viewer/src/components/pages/Cart/OptionSelectorSheet.tsx
+++ b/apps/frontend-menu-viewer/src/components/pages/Cart/OptionSelectorSheet.tsx
@@ -1,0 +1,13 @@
+export default function OptionSelectorSheet() {
+  return (
+    <div className="z-40 fixed inset-0 bg-black/25 min-w-xs xl:mx-auto xl:max-w-5xl w-full h-full">
+      <div className=" absolute bg-white bottom-0 h-5/6 w-full wrapper rounded-t-2xl p-5">
+        <div className="mb-6 flex items-center justify-between gap-12 pb-2">
+          <h2 className="text-mb-3 text-gray-900">{}</h2>
+          <button>엑스</button>
+        </div>
+        <ul></ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend-menu-viewer/src/components/pages/MenuDetail/OptionGroup.tsx
+++ b/apps/frontend-menu-viewer/src/components/pages/MenuDetail/OptionGroup.tsx
@@ -1,6 +1,7 @@
 import { showCustomToast } from '../../../utilities/showToast';
 import Chip from '../../common/Chip';
 import Divider from '../../common/Divider';
+import MinMaxText from '../../common/MinMaxText';
 import OptionSelector from './OptionSelector';
 
 interface Props {
@@ -26,17 +27,12 @@ export default function OptionGroup({
             <h2 className="text-mb-3 text-gray-800">{group.title}</h2>
             {group.required && <Chip label="필수" color="blue" />}
           </div>
-          {type === 'checkbox' && (
-            <p className="text-mc-2 mt-2 flex items-center gap-1 text-gray-500">
-              {group.minSelectable && (
-                <>
-                  <span> 최소 {group.minSelectable}개</span>
-                  <div className="h-1 w-1 rounded-full bg-gray-500"></div>
-                </>
-              )}
-              <span> 최대 {group.maxSelectable}개 선택</span>
-            </p>
-          )}
+          <div className="mt-2">
+            <MinMaxText
+              minSelectable={group.minSelectable}
+              maxSelectable={group.maxSelectable}
+            />
+          </div>
         </div>
         <div className="flex flex-col gap-6">
           {group.items.map((item) => (
@@ -54,7 +50,7 @@ export default function OptionGroup({
                 ) {
                   showCustomToast({
                     icon: 'error',
-                    message: '이미 최대 개수만큼 선택하셨어요!',
+                    message: `최대 ${group.maxSelectable}개까지만 선택할 수 있어요`,
                   });
                 } else {
                   onToggle(item.id);

--- a/apps/frontend-menu-viewer/src/components/pages/MenuDetail/OptionSelector.tsx
+++ b/apps/frontend-menu-viewer/src/components/pages/MenuDetail/OptionSelector.tsx
@@ -46,14 +46,12 @@ function SelectorIcon({
     return (
       <div
         className={`flex h-6 w-6 items-center justify-center rounded-full border transition-colors duration-200 ${
-          checked ? 'bg-main-500 border-main-500' : 'border-gray-200'
+          checked ? 'bg-main-500 border-main-500' : 'border-gray-200 bg-white'
         }`}
       >
         {checked && <div className="h-3 w-3 rounded-full bg-white" />}
       </div>
     );
   }
-  return (
-    <CheckBox checked={checked}/>
-  );
+  return <CheckBox checked={checked} />;
 }

--- a/apps/frontend-menu-viewer/src/index.css
+++ b/apps/frontend-menu-viewer/src/index.css
@@ -8,6 +8,17 @@
   font-display: swap;
 }
 
+@keyframes sheet-enter {
+  0% {
+    opacity: 0;
+    transform: translateY(50%);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes button-enter {
   0% {
     opacity: 0;
@@ -18,7 +29,6 @@
     transform: translateY(0);
   }
 }
-
 
 @keyframes toast-enter {
   0% {
@@ -40,6 +50,10 @@
     opacity: 0;
     transform: translateY(20px);
   }
+}
+
+.animate-sheet-in {
+  animation: sheet-enter 0.2s ease-in-out forwards;
 }
 
 .animate-button-in {

--- a/apps/frontend-menu-viewer/src/pages/Cart.tsx
+++ b/apps/frontend-menu-viewer/src/pages/Cart.tsx
@@ -3,18 +3,43 @@ import CheckBox from '../components/common/CheckBox';
 import Header from '../components/common/Header';
 import OutlineButton from '../components/common/OutlineButton';
 import QuantityCounter from '../components/common/QuantityCounter';
+import OptionDropDown from '../components/pages/Cart/OptionDropDown';
 import { ROUTES } from '../constants/routes';
 import { useCartStore } from '../stores/useCartStore';
+import { useMenuSelectionStore } from '../stores/useMenuSelectionStore';
 import formatNumber from '../utilities/formatNumber';
 import { getStoreId } from '../utilities/getStoreId';
+import { isAllRequiredSelected } from '../utilities/isAllRequiredSelected';
 import { showCustomToast } from '../utilities/showToast';
 import BaseButton from '@/components/common/BaseButton';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
 export default function Cart() {
   const navigate = useNavigate();
-  const { items, getTotalPrice, setQuantity, toggleSelect, clearCart } =
-    useCartStore();
+  const {
+    items,
+    getTotalPrice,
+    setQuantity,
+    toggleSelect,
+    clearCart,
+    getSelectedItemCount,
+    updateItem,
+  } = useCartStore();
+  const {
+    menuId,
+    menu,
+    startEdit,
+    optionPrice,
+    selectedOptions,
+    toggleOption,
+    resetSelection,
+  } = useMenuSelectionStore();
+
+  useEffect(() => {
+    resetSelection();
+  }, []);
+
   return (
     <div className="min-w-xs mx-auto flex h-full w-full flex-col">
       <Header title="주문하기" />
@@ -34,10 +59,10 @@ export default function Cart() {
                     )}
                   </div>
                   <div className="flex flex-col w-full">
-                    <h2 className="text-mb-6 mb-2 text-gray-700">
+                    <h2 className="text-mb-5 mb-2 text-gray-700">
                       {item.originalItem.name}
                     </h2>
-                    <ul className="flex mb-3 flex-col gap-2">
+                    <ul className="flex mb-3 flex-col gap-1">
                       {item.originalItem.optionGroups.map((group) => {
                         const selectedOptionsSet =
                           item.selectedOptions[group.id];
@@ -69,8 +94,11 @@ export default function Cart() {
                       )}
                       원
                     </p>
-                    <div className="mt-3 flex gap-3 justify-end w-full">
-                      <button className="text-mc-1 text-gray-700 flex flex-col items-center justify-center py-1 h-10 px-3 border border-gray-200 rounded-2xl bg-white ">
+                    <div className="mt-3 flex gap-3 justify-end items-center w-full">
+                      <button
+                        onClick={() => startEdit(item)}
+                        className="text-mc-1 text-gray-700 flex flex-col items-center justify-center py-1 h-7 px-3 border border-gray-200 rounded-2xl bg-white "
+                      >
                         옵션 변경
                       </button>
                       <QuantityCounter
@@ -91,10 +119,62 @@ export default function Cart() {
         >
           메뉴 더 추가하기
         </OutlineButton>
+        {menu && (
+          <div className="z-40 fixed inset-0 bg-black/25 min-w-xs xl:mx-auto xl:max-w-5xl w-full h-full">
+            <div className="scrollbar-hide overflow-y-auto absolute bg-white bottom-0 h-5/6 w-full rounded-t-2xl ">
+              <div className="pt-5 wrapper bg-white sticky top-0 mb-6 flex items-center justify-between gap-12 pb-2">
+                <h2 className="text-mb-3 text-gray-900">{menu.name}</h2>
+                <button
+                  onClick={() => {
+                    resetSelection();
+                  }}
+                >
+                  엑스
+                </button>
+              </div>
+              <ul className="space-y-3 wrapper">
+                {menu.optionGroups.map((group) => (
+                  <OptionDropDown
+                    key={group.id}
+                    group={group}
+                    selectedOptionIds={selectedOptions[group.id] ?? new Set()}
+                    onToggle={(itemId) =>
+                      toggleOption(
+                        group.id,
+                        itemId,
+                        group.maxSelectable === 1 && group.required,
+                      )
+                    }
+                  />
+                ))}
+              </ul>
+              <div className="h-48"></div>
+            </div>
+            <ButtonWrapper>
+              <BaseButton
+                disabled={
+                  !isAllRequiredSelected(menu.optionGroups, selectedOptions)
+                }
+                onClick={() => {
+                  if (menuId) {
+                    updateItem(menuId, {
+                      optionPrice: optionPrice,
+                      selectedOptions: selectedOptions,
+                    });
+                    resetSelection();
+                  }
+                }}
+              >
+                변경하기
+              </BaseButton>
+            </ButtonWrapper>
+          </div>
+        )}
 
         {items.length > 0 && (
           <ButtonWrapper>
             <BaseButton
+              disabled={getSelectedItemCount() === 0}
               onClick={() => {
                 clearCart();
                 navigate(ROUTES.STORES.DETAIL(getStoreId()), { replace: true });
@@ -112,7 +192,7 @@ export default function Cart() {
                   <span>주문하기</span>
                 </p>
                 <p className="text-xs font-bold leading-[150%] tracking-[-2%]  flex h-6 w-6 flex-col items-center justify-center rounded-full bg-white text-gray-800">
-                  {items.length}
+                  {getSelectedItemCount()}
                 </p>
               </div>
             </BaseButton>

--- a/apps/frontend-menu-viewer/src/pages/Cart.tsx
+++ b/apps/frontend-menu-viewer/src/pages/Cart.tsx
@@ -3,13 +3,12 @@ import CheckBox from '../components/common/CheckBox';
 import Header from '../components/common/Header';
 import OutlineButton from '../components/common/OutlineButton';
 import QuantityCounter from '../components/common/QuantityCounter';
-import OptionDropDown from '../components/pages/Cart/OptionDropDown';
+import OptionSelectorSheet from '../components/pages/Cart/OptionSelectorSheet';
 import { ROUTES } from '../constants/routes';
 import { useCartStore } from '../stores/useCartStore';
 import { useMenuSelectionStore } from '../stores/useMenuSelectionStore';
 import formatNumber from '../utilities/formatNumber';
 import { getStoreId } from '../utilities/getStoreId';
-import { isAllRequiredSelected } from '../utilities/isAllRequiredSelected';
 import { showCustomToast } from '../utilities/showToast';
 import BaseButton from '@/components/common/BaseButton';
 import { useEffect } from 'react';
@@ -25,6 +24,7 @@ export default function Cart() {
     clearCart,
     getSelectedItemCount,
     updateItem,
+    selectAllItems,
   } = useCartStore();
   const {
     menuId,
@@ -42,7 +42,7 @@ export default function Cart() {
 
   return (
     <div className="min-w-xs mx-auto flex h-full w-full flex-col">
-      <Header title="주문하기" />
+      <Header title="주문하기" onBackClick={() => selectAllItems()} />
       <div className="wrapper flex w-full flex-1 flex-col pt-6">
         <ul className="flex flex-col gap-6 mb-6">
           {items.map((item) => (
@@ -120,55 +120,15 @@ export default function Cart() {
           메뉴 더 추가하기
         </OutlineButton>
         {menu && (
-          <div className="z-40 fixed inset-0 bg-black/25 min-w-xs xl:mx-auto xl:max-w-5xl w-full h-full">
-            <div className="scrollbar-hide overflow-y-auto absolute bg-white bottom-0 h-5/6 w-full rounded-t-2xl ">
-              <div className="pt-5 wrapper bg-white sticky top-0 mb-6 flex items-center justify-between gap-12 pb-2">
-                <h2 className="text-mb-3 text-gray-900">{menu.name}</h2>
-                <button
-                  onClick={() => {
-                    resetSelection();
-                  }}
-                >
-                  엑스
-                </button>
-              </div>
-              <ul className="space-y-3 wrapper">
-                {menu.optionGroups.map((group) => (
-                  <OptionDropDown
-                    key={group.id}
-                    group={group}
-                    selectedOptionIds={selectedOptions[group.id] ?? new Set()}
-                    onToggle={(itemId) =>
-                      toggleOption(
-                        group.id,
-                        itemId,
-                        group.maxSelectable === 1 && group.required,
-                      )
-                    }
-                  />
-                ))}
-              </ul>
-              <div className="h-48"></div>
-            </div>
-            <ButtonWrapper>
-              <BaseButton
-                disabled={
-                  !isAllRequiredSelected(menu.optionGroups, selectedOptions)
-                }
-                onClick={() => {
-                  if (menuId) {
-                    updateItem(menuId, {
-                      optionPrice: optionPrice,
-                      selectedOptions: selectedOptions,
-                    });
-                    resetSelection();
-                  }
-                }}
-              >
-                변경하기
-              </BaseButton>
-            </ButtonWrapper>
-          </div>
+          <OptionSelectorSheet
+            menu={menu}
+            selectedOptions={selectedOptions}
+            optionPrice={optionPrice}
+            menuId={menuId}
+            onToggle={toggleOption}
+            onUpdate={updateItem}
+            onClose={resetSelection}
+          />
         )}
 
         {items.length > 0 && (

--- a/apps/frontend-menu-viewer/src/pages/Home.tsx
+++ b/apps/frontend-menu-viewer/src/pages/Home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   const { storeId } = useParams<{ storeId: string }>();
   if (!storeId) return <div>error</div>;
 
-  const { items, getTotalPrice } = useCartStore();
+  const { items, getTotalPrice, getSelectedItemCount } = useCartStore();
   const {
     data: storeInfo,
     isLoading: isStoreInfoLoading,
@@ -187,7 +187,7 @@ export default function Home() {
                 <span>주문하기</span>
               </p>
               <p className="text-xs font-bold leading-[150%] tracking-[-2%]  flex h-6 w-6 flex-col items-center justify-center rounded-full bg-white text-gray-800">
-                {items.length}
+                {getSelectedItemCount()}
               </p>
             </div>
           </BaseButton>

--- a/apps/frontend-menu-viewer/src/pages/MenuDetail.tsx
+++ b/apps/frontend-menu-viewer/src/pages/MenuDetail.tsx
@@ -9,6 +9,7 @@ import { useFetchMenuDetailQuery } from '../hooks/useFetchMenuDetailQuery';
 import { useCartStore } from '../stores/useCartStore';
 import { useMenuSelectionStore } from '../stores/useMenuSelectionStore';
 import formatNumber from '../utilities/formatNumber';
+import { isAllRequiredSelected } from '../utilities/isAllRequiredSelected';
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -28,20 +29,6 @@ export default function MenuDetail() {
     optionItemPriceMap,
   } = useMenuSelectionStore();
   const { addItem } = useCartStore();
-
-  function isAllRequiredSelected(
-    optionGroups: IOptionGroup[],
-    selectedOptions: Record<string, Set<string>>,
-  ) {
-    return optionGroups.every((group) => {
-      if (!group.required) return true;
-      const selectedCount = selectedOptions[group.id]?.size ?? 0;
-      const minSelectable = group.minSelectable ?? 0;
-      return (
-        selectedCount >= minSelectable && selectedCount <= group.maxSelectable
-      );
-    });
-  }
 
   useEffect(() => {
     window.scrollTo(0, 0);

--- a/apps/frontend-menu-viewer/src/stores/useCartStore.ts
+++ b/apps/frontend-menu-viewer/src/stores/useCartStore.ts
@@ -48,7 +48,6 @@ export const useCartStore = create<CartStore>()(
           updatedItem.selectedOptions,
         );
         updatedItem.id = newId;
-        console.log(updatedItem);
         state.items[itemIndex] = updatedItem;
       }),
 

--- a/apps/frontend-menu-viewer/src/stores/useCartStore.ts
+++ b/apps/frontend-menu-viewer/src/stores/useCartStore.ts
@@ -1,24 +1,17 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 
-interface CartItem {
-  id: string;
-  selected: boolean;
-  originalItem: IMenuDetail;
-  optionPrice: number;
-  quantity: number;
-  selectedOptions: OptionSelection;
-  optionItemPriceMap: Record<string, number>;
-}
-
 interface CartStore {
-  items: CartItem[];
-  addItem: (item: Omit<CartItem, 'id' | 'selected'>) => void;
+  items: ICartItem[];
+  addItem: (item: Omit<ICartItem, 'id' | 'selected'>) => void;
+  updateItem: (id: string, updates: Partial<ICartItem>) => void;
   removeItem: (id: string) => void;
   toggleSelect: (id: string) => void;
   setQuantity: (id: string, quantity: number) => void;
   clearCart: () => void;
   getTotalPrice: () => number;
+  getSelectedItemCount: () => number;
+  selectAllItems: () => void;
 }
 
 function generateItemId(menuId: string, options: OptionSelection) {
@@ -41,6 +34,22 @@ export const useCartStore = create<CartStore>()(
         } else {
           state.items.push({ ...item, selected: true, id });
         }
+      }),
+    updateItem: (id, updates) =>
+      set((state) => {
+        const itemIndex = state.items.findIndex((i) => i.id === id);
+        if (itemIndex === -1) return;
+
+        const item = state.items[itemIndex];
+        const updatedItem = { ...item, ...updates };
+
+        const newId = generateItemId(
+          updatedItem.originalItem.id,
+          updatedItem.selectedOptions,
+        );
+        updatedItem.id = newId;
+        console.log(updatedItem);
+        state.items[itemIndex] = updatedItem;
       }),
 
     removeItem: (id) =>
@@ -75,5 +84,16 @@ export const useCartStore = create<CartStore>()(
         );
       }, 0);
     },
+
+    getSelectedItemCount: () => {
+      return get().items.filter((item) => item.selected).length;
+    },
+
+    selectAllItems: () =>
+      set((state) => {
+        state.items.forEach((item) => {
+          item.selected = true;
+        });
+      }),
   })),
 );

--- a/apps/frontend-menu-viewer/src/stores/useMenuSelectionStore.ts
+++ b/apps/frontend-menu-viewer/src/stores/useMenuSelectionStore.ts
@@ -3,12 +3,14 @@ import { immer } from 'zustand/middleware/immer';
 
 interface MenuSelectionStore {
   menuId: string | null;
+  menu: IMenuDetail | null;
   quantity: number;
   optionPrice: number;
   selectedOptions: OptionSelection;
   optionItemPriceMap: Record<string, number>;
 
   startMenu: (menu: IMenuDetail) => void;
+  startEdit: (cartItem: ICartItem) => void;
   setQuantity: (qty: number) => void;
   toggleOption: (groupId: string, itemId: string, isSingle: boolean) => void;
   resetSelection: () => void;
@@ -17,6 +19,7 @@ interface MenuSelectionStore {
 export const useMenuSelectionStore = create<MenuSelectionStore>()(
   immer((set) => ({
     menuId: null,
+    menu: null,
     quantity: 1,
     optionPrice: 0,
     selectedOptions: {},
@@ -25,6 +28,7 @@ export const useMenuSelectionStore = create<MenuSelectionStore>()(
     startMenu: (menu) =>
       set((state) => {
         state.menuId = menu.id;
+        state.menu = menu;
         state.quantity = 1;
         state.optionPrice = 0;
         state.selectedOptions = {};
@@ -37,6 +41,16 @@ export const useMenuSelectionStore = create<MenuSelectionStore>()(
         }
 
         state.optionItemPriceMap = map;
+      }),
+
+    startEdit: (cartItem) =>
+      set((state) => {
+        state.menuId = cartItem.id;
+        state.menu = cartItem.originalItem;
+        state.quantity = cartItem.quantity;
+        state.optionPrice = cartItem.optionPrice;
+        state.selectedOptions = cartItem.selectedOptions;
+        state.optionItemPriceMap = cartItem.optionItemPriceMap;
       }),
 
     setQuantity: (qty) =>
@@ -79,9 +93,11 @@ export const useMenuSelectionStore = create<MenuSelectionStore>()(
     resetSelection: () =>
       set((state) => {
         state.menuId = null;
+        state.menu = null;
         state.quantity = 1;
         state.optionPrice = 0;
         state.selectedOptions = {};
+        state.optionItemPriceMap = {};
       }),
   })),
 );

--- a/apps/frontend-menu-viewer/src/types/global.d.ts
+++ b/apps/frontend-menu-viewer/src/types/global.d.ts
@@ -60,3 +60,13 @@ interface IStoreInfo {
   name: string;
   infoItems: IStoreInfoItem[];
 }
+
+interface ICartItem {
+  id: string;
+  selected: boolean;
+  originalItem: IMenuDetail;
+  optionPrice: number;
+  quantity: number;
+  selectedOptions: OptionSelection;
+  optionItemPriceMap: Record<string, number>;
+}

--- a/apps/frontend-menu-viewer/src/utilities/isAllRequiredSelected.ts
+++ b/apps/frontend-menu-viewer/src/utilities/isAllRequiredSelected.ts
@@ -1,0 +1,13 @@
+export function isAllRequiredSelected(
+  optionGroups: IOptionGroup[],
+  selectedOptions: Record<string, Set<string>>,
+) {
+  return optionGroups.every((group) => {
+    if (!group.required) return true;
+    const selectedCount = selectedOptions[group.id]?.size ?? 0;
+    const minSelectable = group.minSelectable ?? 0;
+    return (
+      selectedCount >= minSelectable && selectedCount <= group.maxSelectable
+    );
+  });
+}


### PR DESCRIPTION
## 개요
### 신규 기능
- 장바구니에서 메뉴 옵션 변경 기능이 추가
- 옵션 선택 시 최소/최대 선택 가능 개수 안내 문구가 표시
- 옵션 선택을 위한 모달 시트 UI가 도입

### 버그 수정 및 개선
- 체크박스 및 라디오 버튼의 미선택 상태에 흰색 배경이 명확히 적용
- 옵션 그룹 선택 제한 초과 시 안내 메시지가 최대 선택 가능 개수를 포함해 더 명확하게 변경
- 주문 버튼의 선택 항목 개수 표시가 실제 선택된 항목 수로 정확하게 반영

### 스타일
- 옵션 시트 등장 애니메이션이 추가되어 더욱 자연스러운 UI 전환을 제공

## 이슈

- #38 
