### PR TITLE
fix(be): 카카오 redirect url 수정

### DIFF
--- a/apps/backend/src/auth/admin/admin-auth.controller.ts
+++ b/apps/backend/src/auth/admin/admin-auth.controller.ts
@@ -20,8 +20,26 @@ export class AuthController {
 
   @Get('kakao/redirect')
   @KakaoRedirectSwagger()
-  async kakaoRedirect(@Query('code') code: string) {
-    return this.authService.kakaoLogin({ code });
+  async kakaoRedirect(@Query('code') code: string, @Res() res: Response) {
+    const { accessToken, refreshToken } = await this.authService.kakaoLogin({
+      code,
+    });
+
+    res.cookie('admin-authorization', accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production', // 배포 시엔 반드시 true
+      sameSite: 'lax',
+      maxAge: 1000 * 60 * 60, // 1시간
+    });
+
+    res.cookie('refresh-token', refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 1000 * 60 * 60 * 24 * 365, // 1년
+    });
+
+    res.redirect('http://localhost:3000/auth/callback');
   }
 
   @Post('refresh')

--- a/apps/frontend-menu-viewer/.dockerignore
+++ b/apps/frontend-menu-viewer/.dockerignore
@@ -1,0 +1,30 @@
+# 빌드 시 제외할 디렉토리
+node_modules
+.turbo
+turbo
+.next
+.git
+.gitignore
+
+# 설정 및 빌드 캐시
+*.log
+*.tsbuildinfo
+.DS_Store
+Thumbs.db
+
+# 환경변수 파일 (필요시 컨테이너에 개별 복사)
+*.env
+.env*
+.env
+.env.local
+.env.docker
+.env.production
+
+# Docker 자체
+Dockerfile
+docker-compose.yml
+*.exe
+*.dll
+*.bin
+*.sh
+*.bat


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.

`@coderabbitai` : 제목에 작성하면 알아서 제목 생성

`@coderabbitai summary` : summary 알아서 생성

`ai-review` : 태그 달면 리뷰 생성
-->

## 개요
카카오 리다이렉트 url 로직을 수정하였습니다.
accessToken을 admin-authorization이라는 이름으로 쿠키에 저장하였고, refresh-token을 저장하였습니다.
이후 http://localhost:3000/auth/callback/kakao 로 페이지를 redirect 시켰습니다.


## 이슈
- close #63 